### PR TITLE
[DATA-348] via [DATA-354]

### DIFF
--- a/json-serde/src/main/java/org/openx/data/jsonserde/objectinspector/JsonMapObjectInspector.java
+++ b/json-serde/src/main/java/org/openx/data/jsonserde/objectinspector/JsonMapObjectInspector.java
@@ -36,9 +36,13 @@ public class JsonMapObjectInspector extends StandardMapObjectInspector {
     if (JsonObjectInspectorUtils.checkObject(data) == null) {
       return null;
     }
-    
-    JSONObject jObj = (JSONObject) data;
-    
+    JSONObject jObj;
+    try {
+      jObj = (JSONObject) data;
+    } catch (ClassCastException e) {
+      // If data should actually be a JSONArray, encode it as empty json
+      jObj = new JSONObject();
+    }
     return new JSONObjectMapAdapter(jObj);
   }
 

--- a/json-serde/src/test/java/org/openx/data/jsonserde/JsonSerDeTest.java
+++ b/json-serde/src/test/java/org/openx/data/jsonserde/JsonSerDeTest.java
@@ -578,7 +578,7 @@ public class JsonSerDeTest {
         Object obj = serde.serialize(row, soi);
         
         assertTrue(obj instanceof Text);
-        assertEquals("{\"timestamp\":7898,\"two\":43.2,\"one\":true,\"three\":[],\"four\":\"value1\"}", obj.toString());
+        assertEquals("{\"four\":\"value1\",\"one\":true,\"two\":43.2,\"three\":[],\"timestamp\":7898}", obj.toString());
         
         System.out.println("Output object " + obj.toString());
     }


### PR DESCRIPTION
When a Hive table is defined as a `map`, but is sometimes an `array`, the SerDe now represents those bad entries as `{}` (an empty map, instead of an error).
