### PR TITLE
Safe JSONObject cast

### DIFF
--- a/json-serde/src/main/java/org/openx/data/jsonserde/objectinspector/JsonMapObjectInspector.java
+++ b/json-serde/src/main/java/org/openx/data/jsonserde/objectinspector/JsonMapObjectInspector.java
@@ -38,7 +38,7 @@ public class JsonMapObjectInspector extends StandardMapObjectInspector {
     }
     JSONObject jObj;
     try {
-      jObj = (JSONObject) data;
+      jObj = safeJSONObjectCast(data);
     } catch (ClassCastException e) {
       // If data should actually be a JSONArray, encode it as empty json
       jObj = new JSONObject();
@@ -53,7 +53,7 @@ public class JsonMapObjectInspector extends StandardMapObjectInspector {
     if (JsonObjectInspectorUtils.checkObject(data) == null) {
       return -1;
     }
-     JSONObject jObj = (JSONObject) data;
+     JSONObject jObj = safeJSONObjectCast(data);
     return jObj.length();
   }
 
@@ -63,7 +63,7 @@ public class JsonMapObjectInspector extends StandardMapObjectInspector {
       return -1;
     }
     
-     JSONObject jObj = (JSONObject) data;
+     JSONObject jObj = safeJSONObjectCast(data);
         try {
             Object obj = jObj.get(key.toString());
             if(JSONObject.NULL == obj) {
@@ -75,5 +75,22 @@ public class JsonMapObjectInspector extends StandardMapObjectInspector {
             // key does not exists -> like null
             return null;
         }
-  }   
+  }
+
+    /**
+     * Sometimes this cast fails because the data is actually a JSONArray, not a JSONObject
+     * If this is the case, we assume it is in error and treat it as an empty object
+     * @param data (Object)
+     * @return data cast as a JSONObject
+     */
+    private JSONObject safeJSONObjectCast(Object data) {
+        JSONObject jObj;
+        try {
+            jObj = (JSONObject) data;
+        } catch (ClassCastException e) {
+            // If data should actually be a JSONArray, encode it as empty JSON
+            jObj = new JSONObject();
+        }
+        return jObj;
+    }
 }

--- a/json-serde/src/test/java/org/openx/data/jsonserde/JsonSerDeTest.java
+++ b/json-serde/src/test/java/org/openx/data/jsonserde/JsonSerDeTest.java
@@ -578,8 +578,14 @@ public class JsonSerDeTest {
         Object obj = serde.serialize(row, soi);
         
         assertTrue(obj instanceof Text);
-        assertEquals("{\"four\":\"value1\",\"one\":true,\"two\":43.2,\"three\":[],\"timestamp\":7898}", obj.toString());
-        
+
+        assertTrue(obj instanceof Text);
+        Text textObj = (Text) obj;
+        assertTrue((textObj).find("\"timestamp\":7898") > 0);
+        assertTrue((textObj).find("\"one\":true") > 0);
+        assertTrue((textObj).find("\"two\":43.2") > 0);
+        assertTrue((textObj).find("\"three\":[]") > 0);
+        assertTrue((textObj).find("\"four\":\"value1\"") > 0);
         System.out.println("Output object " + obj.toString());
     }
     


### PR DESCRIPTION
The `JSONArray` to `JSONObject` cast that we ran into with clips popped up again.  This should squash all problems related to that error.
