### PR TITLE
Alternative insensitive

### DIFF
--- a/json-serde/src/main/java/org/openx/data/jsonserde/objectinspector/JsonMapObjectInspector.java
+++ b/json-serde/src/main/java/org/openx/data/jsonserde/objectinspector/JsonMapObjectInspector.java
@@ -59,7 +59,7 @@ public class JsonMapObjectInspector extends StandardMapObjectInspector {
     
      JSONObject jObj = safeJSONObjectCast(data);
         try {
-            Object obj = jObj.get(key.toString());
+            Object obj = jObj.getMap(key.toString());
             if(JSONObject.NULL == obj) {
                 return null;
             } else {

--- a/json-serde/src/main/java/org/openx/data/jsonserde/objectinspector/JsonMapObjectInspector.java
+++ b/json-serde/src/main/java/org/openx/data/jsonserde/objectinspector/JsonMapObjectInspector.java
@@ -48,7 +48,7 @@ public class JsonMapObjectInspector extends StandardMapObjectInspector {
       return -1;
     }
      JSONObject jObj = safeJSONObjectCast(data);
-    return jObj.length();
+    return jObj.mapLength();
   }
 
   @Override

--- a/json-serde/src/test/java/org/openx/data/jsonserde/JsonCapitalStructTest.java
+++ b/json-serde/src/test/java/org/openx/data/jsonserde/JsonCapitalStructTest.java
@@ -1,0 +1,67 @@
+package org.openx.data.jsonserde;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.serde.Constants;
+import org.apache.hadoop.hive.serde2.objectinspector.*;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.SettableStringObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.StringObjectInspector;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.io.Writable;
+import org.junit.Before;
+import org.junit.Test;
+import org.openx.data.jsonserde.json.JSONObject;
+
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Created by nathan.demaria on 5/22/2015.
+ */
+public class JsonCapitalStructTest {
+    static JsonSerDe instance;
+
+    @Before
+    public void setUp() throws Exception {
+        initialize();
+    }
+
+    static public void initialize() throws Exception {
+        instance = new JsonSerDe();
+        Configuration conf = null;
+        Properties tbl = new Properties();
+        // from google video API
+        tbl.setProperty(Constants.LIST_COLUMNS, "fieldname");
+        tbl.setProperty(Constants.LIST_COLUMN_TYPES, "struct<keya:string>".toLowerCase());
+
+        instance.initialize(conf, tbl);
+    }
+
+    @Test
+    public void testCapitalKeyStruct() throws Exception {
+        /*
+         * Confirms behavior that if you have multiple keys with the same
+         * name (case insensitive) in a struct, the second will overwrite it
+         */
+        Writable w = new Text("{\"fieldname\": {\"keya\": \"firstValue\", \"Keya\": \"secondValue\"}}");
+
+        JSONObject result = (JSONObject) instance.deserialize(w);
+
+        StructObjectInspector soi = (StructObjectInspector) instance.getObjectInspector();
+
+        StructField fieldnameStructField = soi.getStructFieldRef("fieldname");
+        Object fieldname = soi.getStructFieldData(result, fieldnameStructField);
+        assertEquals(fieldnameStructField.getFieldObjectInspector().getCategory(), ObjectInspector.Category.STRUCT);
+
+        StructObjectInspector fieldnameSOI = (StructObjectInspector) fieldnameStructField.getFieldObjectInspector();
+
+        StructField ksf = fieldnameSOI.getStructFieldRef("keya");
+        PrimitiveObjectInspector poi = (PrimitiveObjectInspector) ksf.getFieldObjectInspector();
+        SettableStringObjectInspector strOI = (SettableStringObjectInspector) poi;
+
+        Object keya = fieldnameSOI.getStructFieldData(fieldname, ksf);
+        Text value = strOI.getPrimitiveWritableObject(keya);
+
+        assertEquals("secondValue", value.toString());
+    }
+}

--- a/json-serde/src/test/java/org/openx/data/jsonserde/JsonCapitalTest.java
+++ b/json-serde/src/test/java/org/openx/data/jsonserde/JsonCapitalTest.java
@@ -1,0 +1,61 @@
+package org.openx.data.jsonserde;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.serde.Constants;
+import org.apache.hadoop.hive.serde2.objectinspector.MapObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.StructField;
+import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.io.Writable;
+import org.junit.Before;
+import org.junit.Test;
+import org.openx.data.jsonserde.json.JSONObject;
+
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Created by nathan.demaria on 5/22/2015.
+ */
+public class JsonCapitalTest {
+    static JsonSerDe instance;
+
+    @Before
+    public void setUp() throws Exception {
+        initialize();
+    }
+
+    static public void initialize() throws Exception {
+        instance = new JsonSerDe();
+        Configuration conf = null;
+        Properties tbl = new Properties();
+        // from google video API
+        tbl.setProperty(Constants.LIST_COLUMNS, "fieldname");
+        tbl.setProperty(Constants.LIST_COLUMN_TYPES, "map<string,string>".toLowerCase());
+
+        instance.initialize(conf, tbl);
+    }
+
+    @Test
+    public void testCapitalKey() throws Exception {
+        //Test that you can have two keys in a map that differ only by case sensitivity
+        Writable w = new Text("{\"fieldname\": {\"keya\": \"value\", \"Keya\": \"value\"}}");
+
+        JSONObject result = (JSONObject) instance.deserialize(w);
+
+        StructObjectInspector soi = (StructObjectInspector) instance.getObjectInspector();
+
+        StructField sfr = soi.getStructFieldRef("fieldname");
+
+        assertEquals(sfr.getFieldObjectInspector().getCategory(), ObjectInspector.Category.MAP);
+
+        MapObjectInspector moi = (MapObjectInspector) sfr.getFieldObjectInspector();
+
+        Object val =  soi.getStructFieldData(result, sfr) ;
+
+        assertEquals(2, moi.getMapSize(val));
+
+    }
+}

--- a/json-serde/src/test/java/org/openx/data/jsonserde/NestedStructureTest.java
+++ b/json-serde/src/test/java/org/openx/data/jsonserde/NestedStructureTest.java
@@ -37,7 +37,7 @@ import org.openx.data.jsonserde.json.JSONObject;
 public class NestedStructureTest {
      static JsonSerDe instance;
 
-  //@Before
+  @Before
   public void setUp() throws Exception {
     initialize();
   }
@@ -62,7 +62,7 @@ public class NestedStructureTest {
      instance.initialize(conf, tbl);
   }
 
-  //@Test
+  @Test
   public void testDeSerialize() throws Exception {
     // Test that timestamp object can be deserialized
     Writable w = new Text("{ \"kind\": \"youtube#videoListResponse\", \"etag\": \"\\\"79S54kzisD_9SOTfQLu_0TVQSpY/mYlS4-ghMGhc1wTFCwoQl3IYDZc\\\"\", \"pageInfo\": { \"totalResults\": 1, \"resultsPerPage\": 1 }, \"items\": [ { \"kind\": \"youtube#video\", \"etag\": \"\\\"79S54kzisD_9SOTfQLu_0TVQSpY/A4foLs-VO317Po_ulY6b5mSimZA\\\"\", \"id\": \"wHkPb68dxEw\", \"statistics\": { \"viewCount\": \"9211\", \"likeCount\": \"79\", \"dislikeCount\": \"11\", \"favoriteCount\": \"0\", \"commentCount\": \"29\" }, \"topicDetails\": { \"topicIds\": [ \"/m/02mjmr\" ], \"relevantTopicIds\": [ \"/m/0cnfvd\", \"/m/01jdpf\" ] } } ] }");

--- a/json-serde/src/test/java/org/openx/data/jsonserde/NestedStructureTest.java
+++ b/json-serde/src/test/java/org/openx/data/jsonserde/NestedStructureTest.java
@@ -37,7 +37,7 @@ import org.openx.data.jsonserde.json.JSONObject;
 public class NestedStructureTest {
      static JsonSerDe instance;
 
-  @Before
+  //@Before
   public void setUp() throws Exception {
     initialize();
   }
@@ -49,20 +49,20 @@ public class NestedStructureTest {
     // from google video API
     tbl.setProperty(Constants.LIST_COLUMNS, "kind,etag,pageInfo,v_items");
     tbl.setProperty(Constants.LIST_COLUMN_TYPES, ("string,string,"+ 
-                "struct<totalResults:INT,resultsPerPage:INT>," + 
-                "ARRAY<STRUCT<kind:STRING," +
-                    "etag:STRING," +
-                     "id:STRING," +
-                     "v_statistics:STRUCT<viewCount:INT,likeCount:INT,dislikeCount:INT,favoriteCount:INT,commentCount:INT>," +
-                     "topicDetails:STRUCT<topicIds:ARRAY<STRING>,relevantTopicIds:ARRAY<STRING>>" +
-                      ">>").toLowerCase());
+                "struct<totalResults:int,resultsPerPage:int>," + 
+                "array<struct<kind:string," +
+                    "etag:string," +
+                     "id:string," +
+                     "v_statistics:struct<viewCount:int,likeCount:int,dislikeCount:int,favoriteCount:int,commentCount:int>," +
+                     "topicDetails:struct<topicIds:array<string>,relevantTopicIds:array<string>>" +
+                      ">>"));
     tbl.setProperty("mapping.v_items" , "items");
     tbl.setProperty("mapping.v_statistics" , "statistics");
 
      instance.initialize(conf, tbl);
   }
 
-  @Test
+  //@Test
   public void testDeSerialize() throws Exception {
     // Test that timestamp object can be deserialized
     Writable w = new Text("{ \"kind\": \"youtube#videoListResponse\", \"etag\": \"\\\"79S54kzisD_9SOTfQLu_0TVQSpY/mYlS4-ghMGhc1wTFCwoQl3IYDZc\\\"\", \"pageInfo\": { \"totalResults\": 1, \"resultsPerPage\": 1 }, \"items\": [ { \"kind\": \"youtube#video\", \"etag\": \"\\\"79S54kzisD_9SOTfQLu_0TVQSpY/A4foLs-VO317Po_ulY6b5mSimZA\\\"\", \"id\": \"wHkPb68dxEw\", \"statistics\": { \"viewCount\": \"9211\", \"likeCount\": \"79\", \"dislikeCount\": \"11\", \"favoriteCount\": \"0\", \"commentCount\": \"29\" }, \"topicDetails\": { \"topicIds\": [ \"/m/02mjmr\" ], \"relevantTopicIds\": [ \"/m/0cnfvd\", \"/m/01jdpf\" ] } } ] }");
@@ -76,7 +76,7 @@ public class NestedStructureTest {
                 , soi.getStructFieldData(result, soi.getStructFieldRef("etag")));
     
     // now, the trickier fields. pageInfo
-    StructField pageInfoSF = soi.getStructFieldRef("pageinfo");
+    StructField pageInfoSF = soi.getStructFieldRef("pageInfo");
     
     Object pageInfo = soi.getStructFieldData(result, pageInfoSF);
     StructObjectInspector pageInfoOI = (StructObjectInspector) pageInfoSF.getFieldObjectInspector();
@@ -85,7 +85,7 @@ public class NestedStructureTest {
     assertEquals(2, pageInfoOI.getAllStructFieldRefs().size());
     
     // now, let's check totalResults
-    StructField trSF = pageInfoOI.getStructFieldRef("totalresults");
+    StructField trSF = pageInfoOI.getStructFieldRef("totalResults");
     Object totalResults = pageInfoOI.getStructFieldData(pageInfo, trSF);
     
     assertTrue(trSF.getFieldObjectInspector().getCategory() == Category.PRIMITIVE);

--- a/json-serde/src/test/java/org/openx/data/jsonserde/NestedWithMappingTest.java
+++ b/json-serde/src/test/java/org/openx/data/jsonserde/NestedWithMappingTest.java
@@ -44,7 +44,7 @@ import org.openx.data.jsonserde.objectinspector.primitive.JavaStringIntObjectIns
 public class NestedWithMappingTest {
      static JsonSerDe instance;
 
-  //@Before
+  @Before
   public void setUp() throws Exception {
     initialize();
   }
@@ -78,7 +78,7 @@ public class NestedWithMappingTest {
      instance.initialize(conf, tbl);
   }
 
-  //@Test
+  @Test
   public void testDeSerialize() throws Exception {
     // Test that timestamp object can be deserialized
     Writable w = new Text("{ \"ts\":\"2014-08-25T00:24:27.41103928Z\", \"t\":36529, \"Request\":{ \"path\":\"/foo/bar\", \"query\":{\"baz\": [\"ban\"]}, \"headers\":{ \"Accept\":[\"image/webp,*/*;q=0.8\"], \"Accept-Encoding\":[\"identity\"], \"Accept-Language\":[\"en-US,en;q=0.8\"], \"Connection\":[\"keep-alive\"], \"Referer\":[\"http://foo.com/bar\"], \"User-Agent\":[\"Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.1916.153 Safari/537.36\"] }, \"ip\":\"10.0.0.1\" } }");

--- a/json-serde/src/test/java/org/openx/data/jsonserde/NestedWithMappingTest.java
+++ b/json-serde/src/test/java/org/openx/data/jsonserde/NestedWithMappingTest.java
@@ -44,7 +44,7 @@ import org.openx.data.jsonserde.objectinspector.primitive.JavaStringIntObjectIns
 public class NestedWithMappingTest {
      static JsonSerDe instance;
 
-  @Before
+  //@Before
   public void setUp() throws Exception {
     initialize();
   }
@@ -72,14 +72,13 @@ public class NestedWithMappingTest {
     */
     tbl.setProperty(Constants.LIST_COLUMNS, "ts,t,request");
     tbl.setProperty(Constants.LIST_COLUMN_TYPES, ("string,int," +
-        "struct<path:string,ip:string,headers:struct<useragent:array<string>>>").
-            toLowerCase());
+        "struct<path:string,ip:string,headers:struct<useragent:array<string>>>"));
     tbl.setProperty("mapping.useragent" , "User-Agent");
 
      instance.initialize(conf, tbl);
   }
 
-  @Test
+  //@Test
   public void testDeSerialize() throws Exception {
     // Test that timestamp object can be deserialized
     Writable w = new Text("{ \"ts\":\"2014-08-25T00:24:27.41103928Z\", \"t\":36529, \"Request\":{ \"path\":\"/foo/bar\", \"query\":{\"baz\": [\"ban\"]}, \"headers\":{ \"Accept\":[\"image/webp,*/*;q=0.8\"], \"Accept-Encoding\":[\"identity\"], \"Accept-Language\":[\"en-US,en;q=0.8\"], \"Connection\":[\"keep-alive\"], \"Referer\":[\"http://foo.com/bar\"], \"User-Agent\":[\"Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.1916.153 Safari/537.36\"] }, \"ip\":\"10.0.0.1\" } }");

--- a/json/src/main/java/org/openx/data/jsonserde/json/JSONObject.java
+++ b/json/src/main/java/org/openx/data/jsonserde/json/JSONObject.java
@@ -142,6 +142,7 @@ public class JSONObject {
      * The map where the JSONObject's properties are kept.
      */
     private Map map;
+    private Map sensitiveMap;
 
 
     /**
@@ -158,6 +159,7 @@ public class JSONObject {
      */
     public JSONObject() {
         this.map = new HashMap();
+        this.sensitiveMap = new HashMap();
     }
 
 
@@ -244,13 +246,15 @@ public class JSONObject {
      */
     public JSONObject(Map map) {
         this.map = new HashMap();
+        this.sensitiveMap = new HashMap();
         if (map != null) {
             Iterator i = map.entrySet().iterator();
             while (i.hasNext()) {
                 Map.Entry e = (Map.Entry)i.next();
                 Object value = e.getValue();
                 if (value != null) {
-                    this.map.put(e.getKey(), wrap(value));
+                    this.map.put(e.getKey().toString().toLowerCase(), wrap(value));
+                    this.sensitiveMap.put(e.getKey(), wrap(value));
                 }
             }
         }
@@ -466,6 +470,24 @@ public class JSONObject {
         return object;
     }
 
+    /**
+     * Get the value object associated with a case sensitive
+     *
+     * @param key   A key string.
+     * @return      The object associated with the key.
+     * @throws      JSONException if the key is not found.
+     */
+    public Object getMap(String key) throws JSONException {
+        if (key == null) {
+            throw new JSONException("Null key.");
+        }
+        Object object = optMap(key);
+        if (object == null) {
+            throw new JSONException("JSONObject[" + quote(key) +
+                    "] not found.");
+        }
+        return object;
+    }
 
     /**
      * Get the boolean value associated with a key.
@@ -660,7 +682,15 @@ public class JSONObject {
     public boolean has(String key) {
         return this.map.containsKey(key);
     }
-    
+
+    /**
+     * In case I want to use case sensitive keys (like for Map)
+     * @param key   A key string.
+     * @return      true if the key exists in the json object
+     */
+    public boolean hasSensitive(String key) {
+        return this.sensitiveMap.containsKey(key);
+    }
     
     /**
      * Increment a property of a JSONObject. If there is no such property,
@@ -775,6 +805,14 @@ public class JSONObject {
         return key == null ? null : this.map.get(key);
     }
 
+    /**
+     * Get an optional value associated with a key.
+     * @param key   A key string.
+     * @return      An object which is the value, or null if there is no value.
+     */
+    public Object optMap(String key) {
+        return key == null ? null : this.sensitiveMap.get(key);
+    }
 
     /**
      * Get an optional boolean associated with a key.
@@ -998,7 +1036,8 @@ public class JSONObject {
 
                         Object result = method.invoke(bean, (Object[])null);
                         if (result != null) {
-                            map.put(key, wrap(result));
+                            map.put(key.toLowerCase(), wrap(result));
+                            sensitiveMap.put(key, wrap(result));
                         }
                     }
                 }
@@ -1109,7 +1148,8 @@ public class JSONObject {
         }
         if (value != null) {
             testValidity(value);
-            this.map.put(key, value);
+            this.map.put(key.toLowerCase(), value);
+            this.sensitiveMap.put(key, value);
         } else {
             remove(key);
         }

--- a/json/src/main/java/org/openx/data/jsonserde/json/JSONObject.java
+++ b/json/src/main/java/org/openx/data/jsonserde/json/JSONObject.java
@@ -172,7 +172,7 @@ public class JSONObject {
         this();
         for (int i = 0; i < names.length; i += 1) {
             try {
-                putOnce(names[i].toLowerCase(), jo.opt(names[i]));
+                putOnce(names[i], jo.opt(names[i]));
             } catch (JSONException ignore) {
             }
         }
@@ -202,7 +202,7 @@ public class JSONObject {
                 return;
             default:
                 x.back();
-                key = x.nextValue().toString().toLowerCase();
+                key = x.nextValue().toString();
             }
 
 // The key is followed by ':'. We will also tolerate '=' or '=>'.
@@ -299,7 +299,7 @@ public class JSONObject {
         for (int i = 0; i < names.length; i += 1) {
             String name = names[i];
             try {
-                putOpt(name.toLowerCase(), c.getField(name).get(object));
+                putOpt(name, c.getField(name).get(object));
             } catch (Exception ignore) {
             }
         }
@@ -350,11 +350,11 @@ public class JSONObject {
                     JSONObject nextTarget = target.optJSONObject(segment);
                     if (nextTarget == null) {
                         nextTarget = new JSONObject();
-                        target.put(segment.toLowerCase(), nextTarget);
+                        target.put(segment, nextTarget);
                     }
                     target = nextTarget;
                 }
-                target.put(path[last].toLowerCase(), bundle.getString((String)key));
+                target.put(path[last], bundle.getString((String)key));
             }
         }
     }
@@ -383,12 +383,12 @@ public class JSONObject {
         testValidity(value);
         Object object = opt(key);
         if (object == null) {
-            put(key.toLowerCase(), value instanceof JSONArray ?
+            put(key, value instanceof JSONArray ?
                     new JSONArray().put(value) : value);
         } else if (object instanceof JSONArray) {
             ((JSONArray)object).put(value);
         } else {
-            put(key.toLowerCase(), new JSONArray().put(object).put(value));
+            put(key, new JSONArray().put(object).put(value));
         }
         return this;
     }
@@ -409,9 +409,9 @@ public class JSONObject {
         testValidity(value);
         Object object = opt(key);
         if (object == null) {
-            put(key.toLowerCase(), new JSONArray().put(value));
+            put(key, new JSONArray().put(value));
         } else if (object instanceof JSONArray) {
-            put(key.toLowerCase(), ((JSONArray)object).put(value));
+            put(key, ((JSONArray)object).put(value));
         } else {
             throw new JSONException("JSONObject[" + key +
                     "] is not a JSONArray.");

--- a/json/src/main/java/org/openx/data/jsonserde/json/JSONObject.java
+++ b/json/src/main/java/org/openx/data/jsonserde/json/JSONObject.java
@@ -1176,7 +1176,12 @@ public class JSONObject {
      */
     public final JSONObject putOnce(String key, Object value) throws JSONException {
         if (key != null && value != null) {
-            if (opt(key) != null) {
+            /*
+             * NOTE: when a key is used multiple times (case insensitive) the
+             * most recent usage will overwrite all previous values when using
+             * all data structures except for Map<>
+             */
+            if (optMap(key) != null) {
                 throw new JSONException("Duplicate key \"" + key + "\"");
             }
             put(key, value);

--- a/json/src/main/java/org/openx/data/jsonserde/json/JSONObject.java
+++ b/json/src/main/java/org/openx/data/jsonserde/json/JSONObject.java
@@ -751,6 +751,14 @@ public class JSONObject {
         return this.map.size();
     }
 
+    /**
+     * Get the number of keys stored in the case sensitive JSONObject.
+     *
+     * @return The number of keys in the JSONObject.
+     */
+    public int mapLength() {
+        return this.sensitiveMap.size();
+    }
 
     /**
      * Produce a JSONArray containing the names of the elements of this


### PR DESCRIPTION
Different way to deal with duplicate case insensitive keys:

Instead of making non-lowercase struct fields kinda invisible, makes duplicate (but distinct when being case sensitive) keys in structs overwrite previous values

I did have to add another `Map` that might not be the best way to do this :disappointed: 
